### PR TITLE
handle omits in tidy_qPCR. cq_average populates missing values

### DIFF
--- a/R/tidy_qPCR.R
+++ b/R/tidy_qPCR.R
@@ -26,7 +26,10 @@ tidy_df <- df_raw %>%
            target_class = dplyr::case_when(
              stringr::str_detect(target, ref_tgt) ~ "house",
              stringr::str_detect(target, exp_tgt) ~ "exp"),
-           target_class = as.factor(target_class))
+           target_class = as.factor(target_class)) %>%
+    dplyr::group_by(sample, target) %>%
+    dplyr::mutate(cq_mean = mean(cq, na.rm = T)) %>%
+    dplyr::ungroup()
 
 tidy_df
 


### PR DESCRIPTION
Fixes an issue where some omitting data from a single well caused an error in dCt calculation. Now when a well is omitted, it is still given the average Cq value for the remaining wells of the same sample and target.